### PR TITLE
Let the program get its name from its arguments

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <libgen.h>
 
 #include "sha1.h"
 
@@ -22,7 +23,7 @@ int main(int argc, char** argv)
 
 	if (argc < 2) 
 	{
-		printf("Usage: test <file>\n");
+		printf("Usage: %s <file>\n", basename(argv[0]));
 		return 1;
 	}
 


### PR DESCRIPTION
The program is currently named "test" which is probably a leftover from early development. I simply changed this to get the name from the first argument and applied basename to this value to strip the path in case it is not executed from the same path (very likely after installing).