### PR TITLE
use size_t for SHA1DCUpdate()

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -1053,7 +1053,7 @@ void SHA1DCSetCallback(SHA1_CTX* ctx, collision_block_callback callback)
 	ctx->callback = callback;
 }
 
-void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, unsigned len) 
+void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 {
 	unsigned left, fill;
 	if (len == 0) 

--- a/lib/sha1.h
+++ b/lib/sha1.h
@@ -6,6 +6,7 @@
 ***/
 
 #include <stdint.h>
+#include <stddef.h>
 
 // uses SHA-1 message expansion to expand the first 16 words of W[] to 80 words
 void sha1_message_expansion(uint32_t W[80]);
@@ -87,7 +88,7 @@ void SHA1DCSetDetectReducedRoundCollision(SHA1_CTX*, int);
 void SHA1DCSetCallback(SHA1_CTX*, collision_block_callback);
 
 // update SHA-1 context with buffer contents
-void SHA1DCUpdate(SHA1_CTX*, const char*, unsigned);
+void SHA1DCUpdate(SHA1_CTX*, const char*, size_t);
 
 // obtain SHA-1 hash from SHA-1 context
 // returns: 0 = no collision detected, otherwise = collision found => warn user for active attack


### PR DESCRIPTION
Using `size_t` instead of `unsinged` should allow to hash more than UINT_MAX bytes at once.

With this unnecessary constructs like https://github.com/HW42/git/blob/7c6ff0baa3a44b3abe4a86a95a5d6ed5260effbe/sha1-cd/sha1.c#L11-L21 are avoidable.

This also makes the interface more similar to the OpenSSL API.