### PR TITLE
Use symlink instead of copy to save disk space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ sha1dcsum: bin/sha1dcsum
 
 .PHONY: sha1dcsum_partialcoll
 sha1dcsum_partialcoll: bin/sha1dcsum
-	cp bin/sha1dcsum bin/sha1dcsum_partialcoll
+	-ln -s sha1dcsum bin/sha1dcsum_partialcoll
 
 .PHONY: library
 library: bin/libdetectcoll.la


### PR DESCRIPTION
Note: I can't test this in this state on macOS as this state does not compile (yet). Please test it on Linux!