### PR TITLE
Amend the lib/ code for easier inclusion in other programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,49 @@ else
     printf("no collision detected");
 ```
 
+## Inclusion in other programs
+
+In order to make it easier to include these sources in other project
+there are several preprocessor macros that the code uses. Rather than
+copy/pasting and customizing or specializing the code, first see if
+setting any of these defines appropriately will allow you to avoid
+modifying the code yourself.
+
+- SHA1DC_NO_STANDARD_INCLUDES
+
+ Skips including standard headers. Use this if your project for
+ whatever reason wishes to do its own header includes.
+
+- SHA1DC_CUSTOM_INCLUDE_SHA1_C
+
+  Includes a custom header at the top of sha1.c. Usually this would be
+  set in conjunction with SHA1DC_NO_STANDARD_INCLUDES to point to a
+  header file which includes various standard headers.
+
+- SHA1DC_INIT_SAFE_HASH_DEFAULT
+
+  Sets the default for safe_hash in SHA1DCInit(). Valid values are 0
+  and 1. If unset 1 is the default.
+
+- SHA1DC_CUSTOM_TRAILING_INCLUDE_SHA1_C
+
+  Includes a custom trailer in sha1.c. Useful for any extra utility
+  functions that make use of the functions already defined in sha1.c.
+
+- SHA1DC_CUSTOM_TRAILING_INCLUDE_SHA1_H
+
+  Includes a custom trailer in sha1.h. Useful for defining the
+  prototypes of the functions or code included by
+  SHA1DC_CUSTOM_TRAILING_INCLUDE_SHA1_C.
+
+- SHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C
+
+  Includes a custom header at the top of ubc_check.c.
+
+- SHA1DC_CUSTOM_TRAILING_INCLUDE_UBC_CHECK_C
+
+  Includes a custom trailer in ubc_check.c.
+
+- SHA1DC_CUSTOM_TRAILING_INCLUDE_UBC_CHECK_H
+
+  Includes a custom trailer in ubc_check.H.

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -5,10 +5,20 @@
 * https://opensource.org/licenses/MIT
 ***/
 
+#ifndef SHA1DC_NO_STANDARD_INCLUDES
 #include <string.h>
 #include <memory.h>
 #include <stdio.h>
 #include <stdlib.h>
+#endif
+
+#ifdef SHA1DC_CUSTOM_INCLUDE_SHA1_C
+#include SHA1DC_CUSTOM_INCLUDE_SHA1_C
+#endif
+
+#ifndef SHA1DC_INIT_SAFE_HASH_DEFAULT
+#define SHA1DC_INIT_SAFE_HASH_DEFAULT 1
+#endif
 
 #include "sha1.h"
 #include "ubc_check.h"
@@ -1678,7 +1688,7 @@ void SHA1DCInit(SHA1_CTX* ctx)
 	ctx->ihv[3] = 0x10325476;
 	ctx->ihv[4] = 0xC3D2E1F0;
 	ctx->found_collision = 0;
-	ctx->safe_hash = 1;
+	ctx->safe_hash = SHA1DC_INIT_SAFE_HASH_DEFAULT;
 	ctx->ubc_check = 1;
 	ctx->detect_coll = 1;
 	ctx->reduced_round_coll = 0;
@@ -1804,3 +1814,7 @@ int SHA1DCFinal(unsigned char output[20], SHA1_CTX *ctx)
 	output[19] = (unsigned char)(ctx->ihv[4]);
 	return ctx->found_collision;
 }
+
+#ifdef SHA1DC_CUSTOM_TRAILING_INCLUDE_SHA1_C
+#include SHA1DC_CUSTOM_TRAILING_INCLUDE_SHA1_C
+#endif

--- a/lib/sha1.h
+++ b/lib/sha1.h
@@ -12,7 +12,9 @@
 extern "C" {
 #endif
 
+#ifndef SHA1DC_NO_STANDARD_INCLUDES
 #include <stdint.h>
+#endif
 
 /* sha-1 compression function that takes an already expanded message, and additionally store intermediate states */
 /* only stores states ii (the state between step ii-1 and step ii) when DOSTORESTATEii is defined in ubc_check.h */
@@ -99,6 +101,10 @@ int  SHA1DCFinal(unsigned char[20], SHA1_CTX*);
 
 #if defined(__cplusplus)
 }
+#endif
+
+#ifdef SHA1DC_CUSTOM_TRAILING_INCLUDE_SHA1_H
+#include SHA1DC_CUSTOM_TRAILING_INCLUDE_SHA1_H
 #endif
 
 #endif

--- a/lib/ubc_check.c
+++ b/lib/ubc_check.c
@@ -24,7 +24,12 @@
 // ubc_check has been verified against ubc_check_verify using the 'ubc_check_test' program in the tools section
 */
 
+#ifndef SHA1DC_NO_STANDARD_INCLUDES
 #include <stdint.h>
+#endif
+#ifdef SHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C
+#include SHA1DC_CUSTOM_INCLUDE_UBC_CHECK_C
+#endif
 #include "ubc_check.h"
 
 static const uint32_t DV_I_43_0_bit 	= (uint32_t)(1) << 0;
@@ -361,3 +366,7 @@ if (mask) {
 
 	dvmask[0]=mask;
 }
+
+#ifdef SHA1DC_CUSTOM_TRAILING_INCLUDE_UBC_CHECK_C
+#include SHA1DC_CUSTOM_TRAILING_INCLUDE_UBC_CHECK_C
+#endif

--- a/lib/ubc_check.h
+++ b/lib/ubc_check.h
@@ -27,7 +27,9 @@
 extern "C" {
 #endif
 
+#ifndef SHA1DC_NO_STANDARD_INCLUDES
 #include <stdint.h>
+#endif
 
 #define DVMASKSIZE 1
 typedef struct { int dvType; int dvK; int dvB; int testt; int maski; int maskb; uint32_t dm[80]; } dv_info_t;
@@ -41,6 +43,10 @@ void ubc_check(const uint32_t W[80], uint32_t dvmask[DVMASKSIZE]);
 
 #if defined(__cplusplus)
 }
+#endif
+
+#ifdef SHA1DC_CUSTOM_TRAILING_INCLUDE_UBC_CHECK_H
+#include SHA1DC_CUSTOM_TRAILING_INCLUDE_UBC_CHECK_H
 #endif
 
 #endif


### PR DESCRIPTION
This introduces no functional changes, but allows the lib/ code to be
used as-is in other programs without patching these files directly.

With these changes the git project can use this code without any
modifications to the upstream code.

This is used by a patch series I've just submitted as an RFC against git.git: https://public-inbox.org/git/20170517113824.31700-1-avarab@gmail.com/T/#u

Currently that patch series points at my fork, but it would be great if you could merge this (or if you'd like to have this done differently, I'm happy to change it), then projects like git could use your code as-is via either a submodule, or just by copying the code as-is with no customizations to the files themselves, only to the Makefile that makes use of them.