### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@
 *.exe
 *.out
 *.app
+
+# Generated directories
+/dep_lib/
+/obj_lib/
+/dep_src/
+/obj_src/
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 /dep_src/
 /obj_src/
 /bin/
+
+# The git.git project generates lib/.depend/ with
+# COMPUTE_HEADER_DEPENDENCIES=[auto|yes].
+.depend/

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -1743,7 +1743,6 @@ void SHA1DCSetCallback(SHA1_CTX* ctx, collision_block_callback callback)
 void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 {
 	unsigned left, fill;
-	const uint32_t* buffer_to_hash = NULL;
 
 	if (len == 0)
 		return;
@@ -1765,12 +1764,11 @@ void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 		ctx->total += 64;
 
 #if defined(SHA1DC_ALLOW_UNALIGNED_ACCESS)
-		buffer_to_hash = (const uint32_t*)buf;
+		sha1_process(ctx, (uint32_t*)(buf));
 #else
-		buffer_to_hash = (const uint32_t*)ctx->buffer;
 		memcpy(ctx->buffer, buf, 64);
+		sha1_process(ctx, (uint32_t*)(ctx->buffer));
 #endif /* defined(SHA1DC_ALLOW_UNALIGNED_ACCESS) */
-		sha1_process(ctx, buffer_to_hash);
 		buf += 64;
 		len -= 64;
 	}

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -24,7 +24,7 @@
 #include "ubc_check.h"
 
 
-/* 
+/*
    Because Little-Endian architectures are most common,
    we only set SHA1DC_BIGENDIAN if one of these conditions is met.
    Note that all MSFT platforms are little endian,
@@ -1643,7 +1643,7 @@ static void sha1_process(SHA1_CTX* ctx, const uint32_t block[16])
 	unsigned i, j;
 	uint32_t ubc_dv_mask[DVMASKSIZE] = { 0xFFFFFFFF };
 	uint32_t ihvtmp[5];
-	
+
 	ctx->ihv1[0] = ctx->ihv[0];
 	ctx->ihv1[1] = ctx->ihv[1];
 	ctx->ihv1[2] = ctx->ihv[2];

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -32,18 +32,15 @@
    If you are compiling on a big endian platform and your compiler does not define one of these,
    you will have to add whatever macros your tool chain defines to indicate Big-Endianness.
  */
-#ifdef SHA1DC_BIGENDIAN
-#undef SHA1DC_BIGENDIAN
-#endif
+#ifndef SHA1DC_BIGENDIAN
 #if (!defined SHA1DC_FORCE_LITTLEENDIAN) && \
     ((defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN)) || \
     (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __BIG_ENDIAN__)) || \
     defined(_BIG_ENDIAN) || defined(__BIG_ENDIAN__) || defined(__ARMEB__) || defined(__THUMBEB__) ||  defined(__AARCH64EB__) || \
     defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__) || defined(SHA1DC_FORCE_BIGENDIAN))
-
 #define SHA1DC_BIGENDIAN
-
-#endif /*ENDIANNESS SELECTION*/
+#endif
+#endif
 
 #if (defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || \
      defined(i386) || defined(__i386) || defined(__i386__) || defined(__i486__)  || \

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -42,16 +42,15 @@
 #endif
 #endif
 
+#ifndef SHA1DC_ALLOW_UNALIGNED_ACCESS
 #if (defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || \
      defined(i386) || defined(__i386) || defined(__i386__) || defined(__i486__)  || \
      defined(__i586__) || defined(__i686__) || defined(_M_IX86) || defined(__X86__) || \
      defined(_X86_) || defined(__THW_INTEL__) || defined(__I86__) || defined(__INTEL__) || \
      defined(__386) || defined(_M_X64) || defined(_M_AMD64))
-
 #define SHA1DC_ALLOW_UNALIGNED_ACCESS
-
-#endif /*UNALIGNMENT DETECTION*/
-
+#endif
+#endif
 
 #define rotate_right(x,n) (((x)>>(n))|((x)<<(32-(n))))
 #define rotate_left(x,n)  (((x)<<(n))|((x)>>(32-(n))))

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -1747,8 +1747,7 @@ void SHA1DCSetCallback(SHA1_CTX* ctx, collision_block_callback callback)
 void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 {
 	unsigned left, fill;
-
-    const uint32_t* buffer_to_hash = NULL;
+	const uint32_t* buffer_to_hash = NULL;
 
 	if (len == 0)
 		return;
@@ -1770,10 +1769,10 @@ void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 		ctx->total += 64;
 
 #if defined(SHA1DC_ALLOW_UNALIGNED_ACCESS)
-        buffer_to_hash = (const uint32_t*)buf;
+		buffer_to_hash = (const uint32_t*)buf;
 #else
-        buffer_to_hash = (const uint32_t*)ctx->buffer;
-        memcpy(ctx->buffer, buf, 64);
+		buffer_to_hash = (const uint32_t*)ctx->buffer;
+		memcpy(ctx->buffer, buf, 64);
 #endif /* defined(SHA1DC_ALLOW_UNALIGNED_ACCESS) */
 		sha1_process(ctx, buffer_to_hash);
 		buf += 64;

--- a/lib/sha1.h
+++ b/lib/sha1.h
@@ -64,7 +64,7 @@ void SHA1DCInit(SHA1_CTX*);
         The best collision attacks against SHA-1 have complexity about 2^60,
         thus for 240-steps an immediate lower-bound for the best cryptanalytic attacks would be 2^180.
         An attacker would be better off using a generic birthday search of complexity 2^80.
-  
+
    Enabling safe SHA-1 hashing will result in the correct SHA-1 hash for messages where no collision attack was detected,
    but it will result in a different SHA-1 hash for messages where a collision attack was detected.
    This will automatically invalidate SHA-1 based digital signature forgeries.
@@ -97,7 +97,7 @@ void SHA1DCUpdate(SHA1_CTX*, const char*, size_t);
 
 /* obtain SHA-1 hash from SHA-1 context */
 /* returns: 0 = no collision detected, otherwise = collision found => warn user for active attack */
-int  SHA1DCFinal(unsigned char[20], SHA1_CTX*); 
+int  SHA1DCFinal(unsigned char[20], SHA1_CTX*);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Allows for tweaking a couple of macros from the outside that are now hardcoded, turns the feedback I had on a couple of @shumow's patches into commits to be applied, and fixes up whitespace indentation / trailing whitespace in the code.

This entire series introduces no functional changes.