### PR TITLE
Minor fixes 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@
 *.exe
 *.out
 *.app
+
+# Generated directories
+/dep_lib/
+/obj_lib/
+/dep_src/
+/obj_src/
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 /dep_src/
 /obj_src/
 /bin/
+
+# The git.git project generates lib/.depend/ with
+# COMPUTE_HEADER_DEPENDENCIES=[auto|yes].
+.depend/

--- a/README.md
+++ b/README.md
@@ -124,3 +124,22 @@ modifying the code yourself.
 - SHA1DC_CUSTOM_TRAILING_INCLUDE_UBC_CHECK_H
 
   Includes a custom trailer in ubc_check.H.
+
+This code will try to auto-detect certain things based on
+CPU/platform. Unless you're running on some really obscure CPU or
+porting to a new platform you should not need to tweak this. If you do
+please open an issue at
+https://github.com/cr-marcstevens/sha1collisiondetection
+
+- SHA1DC_FORCE_LITTLEENDIAN / SHA1DC_FORCE_BIGENDIAN
+
+  Override the check for processor endianenss and force either
+  Little-Endian or Big-Endian.
+
+- SHA1DC_FORCE_UNALIGNED_ACCESS
+
+  Permit unaligned access. This will fail on e.g. SPARC processors, so
+  it's only permitted on a whitelist of processors. If your CPU isn't
+  detected as allowing this, and allows unaligned access, setting this
+  may improve performance (or make it worse, if the kernel has to
+  catch and emulate such access on its own).

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -45,7 +45,8 @@
 
 #endif /*ENDIANNESS SELECTION*/
 
-#if (defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || \
+#if (defined SHA1DC_FORCE_UNALIGNED_ACCESS || \
+     defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || \
      defined(i386) || defined(__i386) || defined(__i386__) || defined(__i486__)  || \
      defined(__i586__) || defined(__i686__) || defined(_M_IX86) || defined(__X86__) || \
      defined(_X86_) || defined(__THW_INTEL__) || defined(__I86__) || defined(__INTEL__) || \

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -1748,7 +1748,6 @@ void SHA1DCSetCallback(SHA1_CTX* ctx, collision_block_callback callback)
 void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 {
 	unsigned left, fill;
-	const uint32_t* buffer_to_hash = NULL;
 
 	if (len == 0)
 		return;
@@ -1770,12 +1769,11 @@ void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 		ctx->total += 64;
 
 #if defined(SHA1DC_ALLOW_UNALIGNED_ACCESS)
-		buffer_to_hash = (const uint32_t*)buf;
+		sha1_process(ctx, (uint32_t*)(buf));
 #else
-		buffer_to_hash = (const uint32_t*)ctx->buffer;
 		memcpy(ctx->buffer, buf, 64);
+		sha1_process(ctx, (uint32_t*)(ctx->buffer));
 #endif /* defined(SHA1DC_ALLOW_UNALIGNED_ACCESS) */
-		sha1_process(ctx, buffer_to_hash);
 		buf += 64;
 		len -= 64;
 	}

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -1748,8 +1748,7 @@ void SHA1DCSetCallback(SHA1_CTX* ctx, collision_block_callback callback)
 void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 {
 	unsigned left, fill;
-
-    const uint32_t* buffer_to_hash = NULL;
+	const uint32_t* buffer_to_hash = NULL;
 
 	if (len == 0)
 		return;
@@ -1771,10 +1770,10 @@ void SHA1DCUpdate(SHA1_CTX* ctx, const char* buf, size_t len)
 		ctx->total += 64;
 
 #if defined(SHA1DC_ALLOW_UNALIGNED_ACCESS)
-        buffer_to_hash = (const uint32_t*)buf;
+		buffer_to_hash = (const uint32_t*)buf;
 #else
-        buffer_to_hash = (const uint32_t*)ctx->buffer;
-        memcpy(ctx->buffer, buf, 64);
+		buffer_to_hash = (const uint32_t*)ctx->buffer;
+		memcpy(ctx->buffer, buf, 64);
 #endif /* defined(SHA1DC_ALLOW_UNALIGNED_ACCESS) */
 		sha1_process(ctx, buffer_to_hash);
 		buf += 64;

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -24,7 +24,7 @@
 #include "ubc_check.h"
 
 
-/* 
+/*
    Because Little-Endian architectures are most common,
    we only set SHA1DC_BIGENDIAN if one of these conditions is met.
    Note that all MSFT platforms are little endian,
@@ -1643,7 +1643,7 @@ static void sha1_process(SHA1_CTX* ctx, const uint32_t block[16])
 	unsigned i, j;
 	uint32_t ubc_dv_mask[DVMASKSIZE] = { 0xFFFFFFFF };
 	uint32_t ihvtmp[5];
-	
+
 	ctx->ihv1[0] = ctx->ihv[0];
 	ctx->ihv1[1] = ctx->ihv[1];
 	ctx->ihv1[2] = ctx->ihv[2];

--- a/lib/sha1.h
+++ b/lib/sha1.h
@@ -64,7 +64,7 @@ void SHA1DCInit(SHA1_CTX*);
         The best collision attacks against SHA-1 have complexity about 2^60,
         thus for 240-steps an immediate lower-bound for the best cryptanalytic attacks would be 2^180.
         An attacker would be better off using a generic birthday search of complexity 2^80.
-  
+
    Enabling safe SHA-1 hashing will result in the correct SHA-1 hash for messages where no collision attack was detected,
    but it will result in a different SHA-1 hash for messages where a collision attack was detected.
    This will automatically invalidate SHA-1 based digital signature forgeries.
@@ -97,7 +97,7 @@ void SHA1DCUpdate(SHA1_CTX*, const char*, size_t);
 
 /* obtain SHA-1 hash from SHA-1 context */
 /* returns: 0 = no collision detected, otherwise = collision found => warn user for active attack */
-int  SHA1DCFinal(unsigned char[20], SHA1_CTX*); 
+int  SHA1DCFinal(unsigned char[20], SHA1_CTX*);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Addresses an issue raised in #32. Now there's documentation for SHA1DC_FORCE_LITTLEENDIAN / SHA1DC_FORCE_BIGENDIAN instead, and I've added a corresponding SHA1DC_FORCE_UNALIGNED_ACCESS.

