### PR TITLE
commit 33a694a9ee1b broke all little endian platforms on *BSD

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -10,6 +10,9 @@
 #include <memory.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef __unix__
+#include <sys/types.h> /* make sure macros like _BIG_ENDIAN visible */
+#endif
 #endif
 
 #ifdef SHA1DC_CUSTOM_INCLUDE_SHA1_C

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -57,9 +57,8 @@
 #define SHA1DC_BIGENDIAN
 #endif
 
-#else /* Not under GCC-alike */
-
-#if defined(__BYTE_ORDER) && defined(__BIG_ENDIAN)
+/* Not under GCC-alike */
+#elif defined(__BYTE_ORDER) && defined(__BIG_ENDIAN)
 /*
  * Should detect Big Endian under glibc.git since 14245eb70e ("entered
  * into RCS", 1992-11-25). Defined in <endian.h> which will have been
@@ -70,9 +69,8 @@
 #define SHA1DC_BIGENDIAN
 #endif
 
-#else /* Not under GCC-alike or glibc */
-
-#if defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN)
+/* Not under GCC-alike or glibc */
+#elif defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN)
 /*
  * *BSD and newlib (embeded linux, cygwin, etc).
  * the defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN) part prevents
@@ -83,11 +81,10 @@
 #define SHA1DC_BIGENDIAN
 #endif
 
-#else /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
-
-#if (defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__) || \
-     defined(__MIPSEB__) || defined(__MIPSEB) || defined(_MIPSEB) || \
-     defined(__sparc))
+/* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
+#elif (defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__) || \
+       defined(__MIPSEB__) || defined(__MIPSEB) || defined(_MIPSEB) ||	\
+       defined(__sparc))
 /*
  * Should define Big Endian for a whitelist of known processors. See
  * https://sourceforge.net/p/predef/wiki/Endianness/ and
@@ -95,9 +92,8 @@
  */
 #define SHA1DC_BIGENDIAN
 
-#else /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
-
-#if defined(SHA1DC_ON_INTEL_LIKE_PROCESSOR)
+/* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
+#elif defined(SHA1DC_ON_INTEL_LIKE_PROCESSOR)
 
 /*
  * As a last resort before we do anything else we're not 100% sure
@@ -109,11 +105,7 @@
 /* We do nothing more here for now */
 /*#error "Uncomment this to see if you fall through all the detection"*/
 
-#endif /* !SHA1DC_ON_INTEL_LIKE_PROCESSOR */
-#endif /* Big Endian under whitelist of processors */
-#endif /* Big Endian under *BSD and newlib */
-#endif /* Big Endian under glibc */
-#endif /* Big Endian under GCC-alike */
+#endif /* Big Endian detection */
 
 #if (defined(SHA1DC_FORCE_LITTLEENDIAN) && defined(SHA1DC_BIGENDIAN))
 #undef SHA1DC_BIGENDIAN

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -39,6 +39,7 @@
     ((defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN)) || \
     (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __BIG_ENDIAN__)) || \
     (defined(_BYTE_ORDER) && (_BYTE_ORDER == _BIG_ENDIAN)) || \
+    (defined(__sun) && defined(_BIG_ENDIAN)) || \
     defined(__BIG_ENDIAN__) || defined(__ARMEB__) || defined(__THUMBEB__) ||  defined(__AARCH64EB__) || \
     defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__) || defined(SHA1DC_FORCE_BIGENDIAN))
 

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -72,8 +72,16 @@
 
 #else /* Not under GCC-alike or glibc */
 
-/* *BSD and newlib (embeded linux, cygwin, etc) */
-#if defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && _BYTE_ORDER == _BIG_ENDIAN
+/*
+ * *BSD and newlib (embeded linux, cygwin, etc).
+ * the defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN) part prevents
+ * this condition from matching with Solaris/sparc.
+ * (Solaris defines only one endian macro)
+ * 
+ */
+#if defined(_BYTE_ORDER) && \
+    defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN) &&	\
+    _BYTE_ORDER == _BIG_ENDIAN
 
 #define SHA1DC_BIGENDIAN
 

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -72,18 +72,16 @@
 
 #else /* Not under GCC-alike or glibc */
 
+#if defined(_BYTE_ORDER) && defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN)
 /*
  * *BSD and newlib (embeded linux, cygwin, etc).
  * the defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN) part prevents
  * this condition from matching with Solaris/sparc.
  * (Solaris defines only one endian macro)
- * 
  */
-#if defined(_BYTE_ORDER) && \
-    defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN) &&	\
-    _BYTE_ORDER == _BIG_ENDIAN
-
+#if _BYTE_ORDER == _BIG_ENDIAN
 #define SHA1DC_BIGENDIAN
+#endif
 
 #else /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
 

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -38,7 +38,8 @@
 #if (!defined SHA1DC_FORCE_LITTLEENDIAN) && \
     ((defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN)) || \
     (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __BIG_ENDIAN__)) || \
-    defined(_BIG_ENDIAN) || defined(__BIG_ENDIAN__) || defined(__ARMEB__) || defined(__THUMBEB__) ||  defined(__AARCH64EB__) || \
+    (defined(_BYTE_ORDER) && (_BYTE_ORDER == _BIG_ENDIAN)) || \
+    defined(__BIG_ENDIAN__) || defined(__ARMEB__) || defined(__THUMBEB__) ||  defined(__AARCH64EB__) || \
     defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__) || defined(SHA1DC_FORCE_BIGENDIAN))
 
 #define SHA1DC_BIGENDIAN


### PR DESCRIPTION
Little endian platforms on all *BSD variants are broken since commit 33a694a9ee1b,
because _BIG_ENDIAN is always defined even on little endian platforms.

problem found by nonaka at NetBSD.org