### PR TITLE
Fix for operation on sparc processors

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -48,7 +48,8 @@
 
 #if (defined(_BIG_ENDIAN) || defined(__BIG_ENDIAN) || defined(__BIG_ENDIAN__) || \
      defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__) || \
-     defined(__MIPSEB__) || defined(__MIPSEB) || defined(_MIPSEB))
+     defined(__MIPSEB__) || defined(__MIPSEB) || defined(_MIPSEB) || \
+     defined(__sparc))
 #define SHA1DC_BIGENDIAN
 #endif
 


### PR DESCRIPTION
Old versions of gcc (such as gcc 4.2.1) don't provide any ENDIAN related defines.

Add a check for the sparc architecture, which I think should work on both 32 and
64 bit versions.  Tested with gcc 4.2.1 on FreeBSD, on a Sparc64 machine.
