### PR TITLE
Fix BigEndian detection (hopefully permanently)

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -36,6 +36,28 @@
 #undef SHA1DC_BIGENDIAN
 #endif
 
+#ifdef sun
+
+#ifdef __sparc
+/*
+ * Why not do this generically? Because Linux at least will define
+ * __BIG_ENDIAN but we're only Big Endian if __BYTE_ORDER is
+ * equivalent to __BIG_ENDIAN, but on Solaris SPARC _BIG_ENDIAN is
+ * defined without any value. Thus just checking if _BIG_ENDIAN is
+ * defined on Solaris SPARC works, but we can't just check if it's
+ * defined because on Linux x86 it'll be defined, just as
+ * __BIG_ENDIAN.
+ *
+ * There's probably some easy way out of this, but let's just take the
+ * easy way out here and treat Solaris specially. This is the Oracle
+ * documented way to check for Solaris SPARC. See
+ * http://www.oracle.com/technetwork/server-storage/solaris/portingtosolaris-138514.html
+ */
+#define SHA1DC_BIGENDIAN
+#endif
+
+#else
+
 #if (defined(_BYTE_ORDER) || defined(__BYTE_ORDER) || defined(__BYTE_ORDER__))
 
 #if ((defined(_BYTE_ORDER) && (_BYTE_ORDER == _BIG_ENDIAN)) || \
@@ -51,6 +73,8 @@
      defined(__MIPSEB__) || defined(__MIPSEB) || defined(_MIPSEB) || \
      defined(__sparc))
 #define SHA1DC_BIGENDIAN
+#endif
+
 #endif
 
 #endif

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -83,22 +83,15 @@
 
 #if defined(SHA1DC_ON_INTEL_LIKE_PROCESSOR)
 /*
- * As a last resort before we fall back on _BIG_ENDIAN or whatever
- * else we're not 100% sure about below, we blacklist specific
- * processors here. We could add more, see
- * e.g. https://wiki.debian.org/ArchitectureSpecificsMemo
+ * As a last resort before we do anything else we're not 100% sure
+ * about below, we blacklist specific processors here. We could add
+ * more, see e.g. https://wiki.debian.org/ArchitectureSpecificsMemo
  */
 #else /* Not under GCC-alike or glibc or <processor whitelist>  or <processor blacklist> */
 
-#ifdef _BIG_ENDIAN
-/*
- * Solaris / illumos defines either _LITTLE_ENDIAN or _BIG_ENDIAN in
- * <sys/isa_defs.h>.
- */
-#define SHA1DC_BIGENDIAN
-#else
+/* We do nothing more here for now */
 /*#error "Uncomment this to see if you fall through all the detection"*/
-#endif /* Big Endian because of _BIG_ENDIAN (Solaris)*/
+
 #endif /* !SHA1DC_ON_INTEL_LIKE_PROCESSOR */
 #endif /* Big Endian under whitelist of processors */
 #endif /* Big Endian under glibc */


### PR DESCRIPTION
The 2.13.2 git release with the latest sha1collisiondetection master still broke on Solaris SPARC. These are two commits.

The first one is a failed attempt (there seems to be no `sun` macro, despite what Oracle's docs say, maybe only the latest version?), it's left there for the git history.

The second one rewrites the Big Endian detection completely based on my investigations into how gcc/glibc etc. and finally Solaris have exported specific macros indicating what the endianness is over time.

This hopefully solves the Solaris bug (I've had reports from two SPARC users that it works), doesn't introduce any regressions, and makes the detection easier to understand going forward.