### PR TITLE
sha1c: fix a trivial spelling error

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -962,7 +962,7 @@ static void sha1recompress_fast_ ## t (uint32_t ihvin[5], uint32_t ihvout[5], co
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4127)  /* Complier complains about the checks in the above macro being constant. */
+#pragma warning(disable: 4127)  /* Compiler complains about the checks in the above macro being constant. */
 #endif
 
 #ifdef DOSTORESTATE0


### PR DESCRIPTION
This was originally fixed in git.git's copy of the library in 6412757514 ("Spelling fixes", 2017-06-25).