### PR TITLE
Don't use gcc-specific compilerflags if not using gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,13 @@ INSTALL ?= install
 endif
 
 
+ifeq ($CC,gcc)
 CFLAGS=-O2 -Wall -Werror -Wextra -pedantic -std=c90 -Ilib
 LDFLAGS=
+else
+CFLAGS=-Ilib
+LDFLAGS=
+endif
 
 LT_CC:=$(LIBTOOL) --tag=CC --mode=compile $(CC)
 LT_CC_DEP:=$(CC)


### PR DESCRIPTION
Makes compilation using xlc on AIX (and likely other compilers) not warn so much.