### PR TITLE
Fix for compiling on AIX using IBM XLC compiler

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -84,7 +84,7 @@
 /* Not under GCC-alike or glibc or *BSD or newlib */
 #elif (defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__) || \
        defined(__MIPSEB__) || defined(__MIPSEB) || defined(_MIPSEB) || \
-       defined(__sparc))
+       defined(__sparc) || (defined(__powerpc) && defined(__xlc__)))
 /*
  * Should define Big Endian for a whitelist of known processors. See
  * https://sourceforge.net/p/predef/wiki/Endianness/ and


### PR DESCRIPTION
Building on AIX using XLC gives an error during make test:
Error: Compiled for incorrect endianness
This also breaks in git from 2.13.2

Add a #ifdef guard based on macros defined at [2] and [3].

Should perhaps __xlc__ should should be changed to or combined with _AIX
based on the behavour of GCC on AIX or XL C on Linux.

1. https://github.com/git/git/commit/6b851e536b05e0c8c61f77b9e4c3e7cedea39ff8
2. https://www.ibm.com/support/knowledgecenter/SSGH2K_13.1.3/com.ibm.xlc1313.aix.doc/compiler_ref/macros_platform.html
3. https://www.ibm.com/support/knowledgecenter/SSGH2K_13.1.3/com.ibm.xlc1313.aix.doc/compiler_ref/xlmacros.html