### PR TITLE
.gitignore: Ignore profiling files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 *.dylib
 *.dll
 
+# Profiling
+*.gcda
+*.gcno
+
 # Fortran module files
 *.mod
 *.smod


### PR DESCRIPTION
This is the continuation of e8397b2 (.gitignore: ignore lib/.depend/ and
other .depend/ directories, 2017-05-19) and helps git.git which uses
this as a submodule.

When running 'make coverage' in git.git, we'll find some files (with the
extension of .gcda and .gcno [1]), to be ignored in this submodule.

[1] https://gcc.gnu.org/onlinedocs/gcc/Gcov-Data-Files.html

Signed-off-by: Stefan Beller <sbeller@google.com>