### PR TITLE
Detect endianess on HP-UX

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -93,7 +93,7 @@
 #define SHA1DC_BIGENDIAN
 
 /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
-#elif (defined(_AIX))
+#elif (defined(_AIX) || defined(__hpux))
 
 /*
  * Defines Big Endian on a whitelist of OSs that are known to be Big


### PR DESCRIPTION
HP-UX is not properly detected and classified as little endian. Add test macro
for HP-UX to make it big endian.

Based on the discussion on the [Git mailing list](https://public-inbox.org/git/3cabed9e-3949-93cc-2c9c-500a9cd9d4cd@siemens.com/T/#t), here is the upstream patch for HP-UX detection.