### PR TITLE
lib/sha1.c: Set SHA1DC_BIGENDIAN on OS X PowerPC

### DIFF
--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -92,6 +92,10 @@
  */
 #define SHA1DC_BIGENDIAN
 
+#elif (defined(__APPLE__) && defined(__BIG_ENDIAN__) && !defined(SHA1DC_BIGENDIAN))
+/* older gcc compilers which are the default  on Apple PPC do not define __BYTE_ORDER__ */
+#define SHA1DC_BIGENDIAN
+
 /* Not under GCC-alike or glibc or *BSD or newlib or <processor whitelist> */
 #elif (defined(_AIX) || defined(__hpux))
 


### PR DESCRIPTION
Otherwise it's built in little endian mode.
Resolves #40 